### PR TITLE
fix: #18, fix #19: upcoming periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,9 @@ Pull requests are always welcome! For major changes, please open an issue first 
 
 ## Development
 
+- Running release on device:
+`flutter run --release`
+- Building for release (make sure to update the version before each new release):
+`flutter build appbundle --release`
 - Running emulator via CLI:
 `emulator -avd <AVD_NAME> -no-snapshot-save -no-boot-anim -gpu host -accel on`

--- a/README.md
+++ b/README.md
@@ -16,20 +16,18 @@ Period tracker mobile app I built for my girlfriend. She needed a simple app to 
 
 ## Download
 
-
-
 <p align="center">
   <a href="https://play.google.com/store/apps/details?id=com.lebaaar.period_tracker">
-    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/78/Google_Play_Store_badge_EN.svg/2560px-Google_Play_Store_badge_EN.svg.png" width="33%" alt="Get it on Google Play">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/78/Google_Play_Store_badge_EN.svg/2560px-Google_Play_Store_badge_EN.svg.png" width="220" alt="Get it on Google Play">
   </a>
   <br>
   <br>
   <a href="download/app-release.apk">
-    <img src="https://img.shields.io/badge/Download-APK-blue?logo=android&logoColor=white" width="33%" alt="Download APK">
+    <img src="https://img.shields.io/badge/Download-APK-blue?logo=android&logoColor=white" width="220" alt="Download APK">
   </a>
   <br>
   <p align="center">
-  <i>Available on Google Play Store and as a direct APK download. Not avaliable on App Store because because f*ck Apple and their 99$/year membership</i>
+  <i>Available on Google Play Store and as a direct APK download. Not available on App Store because because f*ck Apple and their 99$/year membership</i>
   </p>
 </p>
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,10 +1,56 @@
 // UI
+import 'package:flutter/rendering.dart';
+import 'package:period_tracker/theme.dart';
+
 final double kBorderRadius = 12;
 final double kTableCalendarDaysOfTheWeekHeight = 30;
 
 // Date constants for calendar range
 final DateTime kFirstCalendarDay = DateTime.utc(2020, 1, 1);
 final DateTime kLastCalendarDay = DateTime.utc(DateTime.now().year + 8, 12, 31);
+
+// table_calendar specific
+// logged period gradients - gradient the whole background
+final Gradient kLoggedPeriodFirstMonthDayGradient = LinearGradient(
+  colors: [colorScheme.surface, colorScheme.secondary],
+  stops: [0.0, 0.33],
+  begin: Alignment.centerLeft,
+  end: Alignment.centerRight,
+);
+final Gradient kLoggedPeriodLastMonthDayGradient = LinearGradient(
+  colors: [colorScheme.secondary, colorScheme.surface],
+  stops: [0.66, 1.0],
+  begin: Alignment.centerLeft,
+  end: Alignment.centerRight,
+);
+
+// logged selected period gradients - gradient the whole background
+final Gradient kLoggedSelectedPeriodFirstMonthDayGradient = LinearGradient(
+  colors: [colorScheme.surface, colorScheme.primary],
+  stops: [0.0, 0.33],
+  begin: Alignment.centerLeft,
+  end: Alignment.centerRight,
+);
+final Gradient kLoggedSelectedPeriodLastMonthDayGradient = LinearGradient(
+  colors: [colorScheme.primary, colorScheme.surface],
+  stops: [0.66, 1.0],
+  begin: Alignment.centerLeft,
+  end: Alignment.centerRight,
+);
+
+// TODO: upcoming period gradients - gradient just the border
+final Gradient kUpcomingSelectedPeriodFirstMonthDayGradient = LinearGradient(
+  colors: [colorScheme.surface, colorScheme.primary],
+  stops: [0.0, 0.33],
+  begin: Alignment.centerLeft,
+  end: Alignment.centerRight,
+);
+final Gradient kUpcomingSelectedPeriodLastMonthDayGradient = LinearGradient(
+  colors: [colorScheme.primary, colorScheme.surface],
+  stops: [0.66, 1.0],
+  begin: Alignment.centerLeft,
+  end: Alignment.centerRight,
+);
 
 // Default cycle and period lengths
 final int kDefaultCycleLength = 28;

--- a/lib/enums/dog_breed.dart
+++ b/lib/enums/dog_breed.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: constant_identifier_names
+
 enum DogBreed {
   affenpinscher("affenpinscher", "Affenpinscher"),
   african_wild("african/wild", "African Wild"),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -61,165 +61,122 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
     return Scaffold(
       body: SafeArea(
         child: SingleChildScrollView(
-        child: Column(
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      Icon(
-                        Icons.calendar_month_rounded,
-                        size: 40,
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                      const SizedBox(width: 12),
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            'Next period:',
-                            style: Theme.of(context).textTheme.bodyMedium,
-                          ),
-                          Text(
-                            nextPeriodDate != null
-                                ? DateTimeHelper.displayDate(nextPeriodDate)
-                                : 'Not enough data',
-                            style: Theme.of(context).textTheme.titleMedium,
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 26),
-                  Text(
-                    'Current cycle day: $currentCycleDay',
-                    style: Theme.of(context).textTheme.bodyMedium,
-                  ),
-                  const SizedBox(height: 8),
-                  LinearProgressIndicator(
-                    value: progress,
-                    valueColor: AlwaysStoppedAnimation<Color>(
-                      Theme.of(context).colorScheme.primary,
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.calendar_month_rounded,
+                          size: 40,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                        const SizedBox(width: 12),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Next period:',
+                              style: Theme.of(context).textTheme.bodyMedium,
+                            ),
+                            Text(
+                              nextPeriodDate != null
+                                  ? DateTimeHelper.displayDate(nextPeriodDate)
+                                  : 'Not enough data',
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                          ],
+                        ),
+                      ],
                     ),
-                    minHeight: 8,
-                    backgroundColor: Theme.of(context).colorScheme.secondary,
-                    borderRadius: BorderRadius.circular(99),
-                  ),
-                  const SizedBox(height: 16),
-                  Text(
-                    status.text,
-                    style: Theme.of(
-                      context,
-                    ).textTheme.bodyMedium?.copyWith(color: status.color),
-                  ),
-                ],
+                    const SizedBox(height: 26),
+                    Text(
+                      'Current cycle day: $currentCycleDay',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 8),
+                    LinearProgressIndicator(
+                      value: progress,
+                      valueColor: AlwaysStoppedAnimation<Color>(
+                        Theme.of(context).colorScheme.primary,
+                      ),
+                      minHeight: 8,
+                      backgroundColor: Theme.of(context).colorScheme.secondary,
+                      borderRadius: BorderRadius.circular(99),
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      status.text,
+                      style: Theme.of(
+                        context,
+                      ).textTheme.bodyMedium?.copyWith(color: status.color),
+                    ),
+                  ],
+                ),
               ),
-            ),
-            // Calendar section
+              // Calendar section
               SizedBox(
                 height: 400,
                 child: TableCalendar(
-              headerStyle: HeaderStyle(formatButtonVisible: false),
-              startingDayOfWeek: StartingDayOfWeek.monday,
-              firstDay: kFirstCalendarDay,
-              lastDay: kLastCalendarDay,
-              focusedDay: _focusedDay,
-              selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
-              rangeStartDay: _rangeStart,
-              rangeEndDay: _rangeEnd,
-              calendarFormat: CalendarFormat.month,
-              rangeSelectionMode: RangeSelectionMode.toggledOff,
-              onDaySelected: (selectedDay, focusedDay) {
-                setState(() {
-                  if (!isSameDay(_selectedDay, selectedDay)) {
-                    _selectedDay = selectedDay;
-                    _focusedDay = focusedDay;
-                    _rangeStart = null;
-                  }
-                });
-              },
-              daysOfWeekHeight: kTableCalendarDaysOfTheWeekHeight,
-              daysOfWeekStyle: DaysOfWeekStyle(
-                weekdayStyle: TextStyle(
-                  color: Theme.of(context).colorScheme.tertiary,
-                ),
-                weekendStyle: TextStyle(
-                  color: Theme.of(context).colorScheme.tertiary,
-                ),
-              ),
-              calendarStyle: CalendarStyle(outsideDaysVisible: false),
-              calendarBuilders: CalendarBuilders(
-                defaultBuilder: (context, day, focusedDay) {
-                  return _defaultBuilder(context, day, focusedDay, periods);
-                },
-                todayBuilder: (context, day, focusedDay) {
-                  final isInPeriod = PeriodService.isInPeriod(day, periods);
-                  if (isInPeriod) {
-                    return _defaultBuilder(context, day, focusedDay, periods);
-                  }
-                  return Container(
-                    margin: const EdgeInsets.fromLTRB(0, 4, 0, 4),
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      border: Border.all(
-                        color: Theme.of(context).colorScheme.primary,
-                        width: 2,
-                      ),
+                  headerStyle: HeaderStyle(formatButtonVisible: false),
+                  startingDayOfWeek: StartingDayOfWeek.monday,
+                  firstDay: kFirstCalendarDay,
+                  lastDay: kLastCalendarDay,
+                  focusedDay: _focusedDay,
+                  selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+                  rangeStartDay: _rangeStart,
+                  rangeEndDay: _rangeEnd,
+                  calendarFormat: CalendarFormat.month,
+                  rangeSelectionMode: RangeSelectionMode.toggledOff,
+                  onDaySelected: (selectedDay, focusedDay) {
+                    setState(() {
+                      if (!isSameDay(_selectedDay, selectedDay)) {
+                        _selectedDay = selectedDay;
+                        _focusedDay = focusedDay;
+                        _rangeStart = null;
+                      }
+                    });
+                  },
+                  daysOfWeekHeight: kTableCalendarDaysOfTheWeekHeight,
+                  daysOfWeekStyle: DaysOfWeekStyle(
+                    weekdayStyle: TextStyle(
+                      color: Theme.of(context).colorScheme.tertiary,
                     ),
-                    child: Center(
-                      child: Text(
-                        '${day.day}',
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.onSurface,
+                    weekendStyle: TextStyle(
+                      color: Theme.of(context).colorScheme.tertiary,
+                    ),
+                  ),
+                  calendarStyle: CalendarStyle(outsideDaysVisible: false),
+                  calendarBuilders: CalendarBuilders(
+                    defaultBuilder: (context, day, focusedDay) =>
+                        _defaultBuilder(
+                          context,
+                          day,
+                          focusedDay,
+                          periods,
+                          nextPeriodDate,
                         ),
-                      ),
+                    todayBuilder: (context, day, focusedDay) => _todayBuilder(
+                      context,
+                      day,
+                      focusedDay,
+                      periods,
+                      nextPeriodDate,
                     ),
-                  );
-                },
-                selectedBuilder: (context, day, focusedDay) {
-                  final isInPeriod = PeriodService.isInPeriod(day, periods);
-                  final isStartDay = PeriodService.isStartDay(day, periods);
-                  final isEndDay = PeriodService.isEndDay(day, periods);
-
-                  BoxDecoration? decoration;
-                  Color? textColor;
-                  if (isInPeriod) {
-                    decoration = BoxDecoration(
-                      color: Theme.of(context).colorScheme.primary,
-                      borderRadius: BorderRadius.horizontal(
-                        left: isStartDay
-                            ? const Radius.circular(99)
-                            : Radius.zero,
-                        right: isEndDay
-                            ? const Radius.circular(99)
-                            : Radius.zero,
-                      ),
-                    );
-                    textColor = Theme.of(context).colorScheme.surface;
-                  } else {
-                    decoration = BoxDecoration(
-                      color: Theme.of(context).colorScheme.primary,
-                      shape: BoxShape.circle,
-                    );
-                    textColor = Theme.of(context).colorScheme.onPrimary;
-                  }
-
-                  return Container(
-                    margin: const EdgeInsets.fromLTRB(0, 4, 0, 4),
-                    decoration: decoration,
-                    child: Center(
-                      child: Text(
-                        '${day.day}',
-                        style: TextStyle(color: textColor),
-                      ),
-                    ),
-                  );
-                },
-              ),
-            ),
+                    selectedBuilder: (context, day, focusedDay) =>
+                        _selectedBuilder(
+                          context,
+                          day,
+                          focusedDay,
+                          periods,
+                          nextPeriodDate,
+                        ),
+                  ),
+                ),
               ),
               Center(
                 child: Padding(
@@ -228,7 +185,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                 ),
               ),
             ],
-            ),
+          ),
         ),
       ),
       floatingActionButton: FloatingActionButton(
@@ -280,7 +237,18 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
     );
   }
 
-  Widget _defaultBuilder(BuildContext context, day, focusedDay, periods) {
+  Widget _defaultBuilder(
+    BuildContext context,
+    DateTime day,
+    DateTime focusedDay,
+    periods,
+    DateTime? nextPeriodDate,
+  ) {
+    // distinguish 3 casesL
+    // - selected date is inside logged period
+    // - selected date is inside upcoming period
+    // - default builder for all other dates
+
     final isInPeriod = PeriodService.isInPeriod(day, periods);
     final isStartDay = PeriodService.isStartDay(day, periods);
     final isEndDay = PeriodService.isEndDay(day, periods);
@@ -288,6 +256,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
     BoxDecoration? decoration;
     Color? textColor;
     if (isInPeriod) {
+      // day is inside logged period
       decoration = BoxDecoration(
         color: Theme.of(context).colorScheme.secondary,
         borderRadius: BorderRadius.horizontal(
@@ -296,6 +265,193 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
         ),
       );
       textColor = Theme.of(context).colorScheme.onSurface;
+    }
+
+    // next period date styling
+    if (nextPeriodDate != null) {
+      DateTime nextPeriodStart = DateTimeHelper.stripTime(nextPeriodDate);
+      DateTime nextPeriodEnd = DateTimeHelper.stripTime(
+        nextPeriodDate.add(Duration(days: 5 - 1)),
+      );
+      DateTime current = DateTimeHelper.stripTime(day);
+      Color primaryColor = Theme.of(context).colorScheme.primary;
+
+      if (DateTimeHelper.dayBetweenDates(
+        current,
+        nextPeriodStart,
+        nextPeriodEnd,
+      )) {
+        // day is inside upcoming period
+        final isNextPeriodStartDay = DateTimeHelper.isSameDay(
+          nextPeriodStart,
+          day,
+        );
+        final isNextPeriodEndDay = DateTimeHelper.isSameDay(nextPeriodEnd, day);
+        decoration = BoxDecoration(
+          border: Border(
+            left: isNextPeriodStartDay
+                ? BorderSide(color: primaryColor, width: 2)
+                : BorderSide.none,
+            right: isNextPeriodEndDay
+                ? BorderSide(color: primaryColor, width: 2)
+                : BorderSide.none,
+            top: BorderSide(color: primaryColor, width: 2),
+            bottom: BorderSide(color: primaryColor, width: 2),
+          ),
+          borderRadius: BorderRadius.horizontal(
+            left: isNextPeriodStartDay
+                ? const Radius.circular(99)
+                : Radius.zero,
+            right: isNextPeriodEndDay ? const Radius.circular(99) : Radius.zero,
+          ),
+        );
+        return Container(
+          margin: const EdgeInsets.fromLTRB(0, 4, 0, 4),
+          decoration: decoration,
+          child: Center(
+            child: Text('${day.day}', style: TextStyle(color: textColor)),
+          ),
+        );
+      }
+    }
+
+    // default builder
+    return Container(
+      margin: const EdgeInsets.fromLTRB(0, 4, 0, 4),
+      decoration: decoration,
+      child: Center(
+        child: Text('${day.day}', style: TextStyle(color: textColor)),
+      ),
+    );
+  }
+
+  Widget _todayBuilder(
+    BuildContext context,
+    DateTime day,
+    DateTime focusedDay,
+    periods,
+    DateTime? nextPeriodDate,
+  ) {
+    // distinguish 3 casesL
+    // - selected date is inside logged period
+    // - selected date is inside upcoming period
+    // - default builder for all other dates
+
+    final isInPeriod = PeriodService.isInPeriod(day, periods);
+
+    if (isInPeriod) {
+      // today is inside logged period
+      return _defaultBuilder(context, day, focusedDay, periods, nextPeriodDate);
+    }
+
+    // default styling that is returned if today is just a regular day, meaning it doesn't fall into any of the logged or upcoming periods
+    BoxDecoration? decoration = BoxDecoration(
+      shape: BoxShape.circle,
+      border: Border.all(
+        color: Theme.of(context).colorScheme.secondary, // TODO, remove?
+        width: 2,
+      ),
+    );
+    Color? textColor = Theme.of(context).colorScheme.onSurface;
+
+    if (nextPeriodDate != null) {
+      DateTime nextPeriodStart = DateTimeHelper.stripTime(nextPeriodDate);
+      DateTime nextPeriodEnd = DateTimeHelper.stripTime(
+        nextPeriodDate.add(Duration(days: 5 - 1)),
+      );
+      DateTime current = DateTimeHelper.stripTime(day);
+
+      if (DateTimeHelper.dayBetweenDates(
+        current,
+        nextPeriodStart,
+        nextPeriodEnd,
+      )) {
+        // selected date is inside upcoming period
+        return _defaultBuilder(
+          context,
+          day,
+          focusedDay,
+          periods,
+          nextPeriodDate,
+        );
+      }
+    }
+
+    return Container(
+      margin: const EdgeInsets.fromLTRB(0, 4, 0, 4),
+      decoration: decoration,
+      child: Center(
+        child: Text('${day.day}', style: TextStyle(color: textColor)),
+      ),
+    );
+  }
+
+  Widget _selectedBuilder(
+    BuildContext context,
+    DateTime day,
+    DateTime focusedDay,
+    periods,
+    DateTime? nextPeriodDate,
+  ) {
+    // distinguish 3 casesL
+    // - selected date is inside logged period
+    // - selected date is inside upcoming period
+    // - default builder for all other dates
+    final isInPeriod = PeriodService.isInPeriod(day, periods);
+    final isStartDay = PeriodService.isStartDay(day, periods);
+    final isEndDay = PeriodService.isEndDay(day, periods);
+
+    bool insideUpcomingPeriod = false;
+    bool isNextPeriodStartDay = false;
+    bool isNextPeriodEndDay = false;
+
+    if (nextPeriodDate != null) {
+      DateTime nextPeriodStart = DateTimeHelper.stripTime(nextPeriodDate);
+      DateTime nextPeriodEnd = DateTimeHelper.stripTime(
+        nextPeriodDate.add(Duration(days: 5 - 1)),
+      );
+      DateTime current = DateTimeHelper.stripTime(day);
+
+      if (DateTimeHelper.dayBetweenDates(
+        current,
+        nextPeriodStart,
+        nextPeriodEnd,
+      )) {
+        isNextPeriodStartDay = DateTimeHelper.isSameDay(nextPeriodStart, day);
+        isNextPeriodEndDay = DateTimeHelper.isSameDay(nextPeriodEnd, day);
+        insideUpcomingPeriod = true;
+      }
+    }
+
+    BoxDecoration? decoration;
+    Color? textColor;
+    if (isInPeriod) {
+      // selected date is inside logged period
+      decoration = BoxDecoration(
+        color: Theme.of(context).colorScheme.primary,
+        borderRadius: BorderRadius.horizontal(
+          left: isStartDay ? const Radius.circular(99) : Radius.zero,
+          right: isEndDay ? const Radius.circular(99) : Radius.zero,
+        ),
+      );
+      textColor = Theme.of(context).colorScheme.surface;
+    } else if (insideUpcomingPeriod) {
+      // selected day is inside upcoming period
+      decoration = BoxDecoration(
+        color: Theme.of(context).colorScheme.primary,
+        borderRadius: BorderRadius.horizontal(
+          left: isNextPeriodStartDay ? const Radius.circular(99) : Radius.zero,
+          right: isNextPeriodEndDay ? const Radius.circular(99) : Radius.zero,
+        ),
+      );
+      textColor = Theme.of(context).colorScheme.surface;
+    } else {
+      // default selector builder
+      decoration = BoxDecoration(
+        color: Theme.of(context).colorScheme.primary,
+        shape: BoxShape.circle,
+      );
+      textColor = Theme.of(context).colorScheme.onPrimary;
     }
 
     return Container(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -60,6 +60,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
 
     return Scaffold(
       body: SafeArea(
+        child: SingleChildScrollView(
         child: Column(
           children: [
             Padding(
@@ -118,7 +119,9 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
               ),
             ),
             // Calendar section
-            TableCalendar(
+              SizedBox(
+                height: 400,
+                child: TableCalendar(
               headerStyle: HeaderStyle(formatButtonVisible: false),
               startingDayOfWeek: StartingDayOfWeek.monday,
               firstDay: kFirstCalendarDay,
@@ -217,15 +220,15 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                 },
               ),
             ),
-            Expanded(
-              child: Center(
+              ),
+              Center(
                 child: Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: periodProvider.getDataForDate(_selectedDay, context),
                 ),
               ),
+            ],
             ),
-          ],
         ),
       ),
       floatingActionButton: FloatingActionButton(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -121,10 +121,9 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                     const SizedBox(height: 16),
                     Text(
                       status.text,
-                            style: Theme.of(context).textTheme.bodyMedium
-                                ?.copyWith(color: status.color),
-                          ),
-                        ],
+                      style: Theme.of(
+                        context,
+                      ).textTheme.bodyMedium?.copyWith(color: status.color),
                     ),
                   ],
                 ),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -55,6 +55,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
       nextPeriodDate,
     );
 
+    bool showProgressBar = avgCycleLength != null;
     double progress = 0;
     if (avgCycleLength != null && avgCycleLength > 0) {
       progress = currentCycleDay / avgCycleLength;
@@ -96,6 +97,10 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                         ),
                       ],
                     ),
+                    if (showProgressBar)
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
                     const SizedBox(height: 26),
                     Text(
                       'Current cycle day: $currentCycleDay',
@@ -108,15 +113,18 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                         Theme.of(context).colorScheme.primary,
                       ),
                       minHeight: 8,
-                      backgroundColor: Theme.of(context).colorScheme.secondary,
+                            backgroundColor: Theme.of(
+                              context,
+                            ).colorScheme.secondary,
                       borderRadius: BorderRadius.circular(99),
                     ),
                     const SizedBox(height: 16),
                     Text(
                       status.text,
-                      style: Theme.of(
-                        context,
-                      ).textTheme.bodyMedium?.copyWith(color: status.color),
+                            style: Theme.of(context).textTheme.bodyMedium
+                                ?.copyWith(color: status.color),
+                          ),
+                        ],
                     ),
                   ],
                 ),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -46,7 +46,10 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
     final currentCycleDay = periodProvider.getCurrentCycleDay(
       DateTime.utc(tempDate.year, tempDate.month, tempDate.day),
     );
-    final avgCycleLength = periodProvider.getAverageCycleLength();
+    final avgCycleLength = periodProvider.getAverageCycleLength(
+      userCycleLength:
+          user?.cycleLength, // provide userCycleLength if available
+    );
     final status = periodProvider.getStatusMessage(
       Theme.of(context).colorScheme.tertiary,
       nextPeriodDate,
@@ -265,7 +268,6 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
           right: isEndDay ? const Radius.circular(99) : Radius.zero,
         ),
       );
-      textColor = Theme.of(context).colorScheme.onSurface;
     }
 
     // next period date styling

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -244,7 +244,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
     periods,
     DateTime? nextPeriodDate,
   ) {
-    // distinguish 3 casesL
+    // distinguish 3 cases:
     // - selected date is inside logged period
     // - selected date is inside upcoming period
     // - default builder for all other dates
@@ -257,6 +257,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
     Color? textColor;
     if (isInPeriod) {
       // day is inside logged period
+      textColor = Theme.of(context).colorScheme.onSurface;
       decoration = BoxDecoration(
         color: Theme.of(context).colorScheme.secondary,
         borderRadius: BorderRadius.horizontal(
@@ -332,7 +333,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
     periods,
     DateTime? nextPeriodDate,
   ) {
-    // distinguish 3 casesL
+    // distinguish 3 cases:
     // - selected date is inside logged period
     // - selected date is inside upcoming period
     // - default builder for all other dates
@@ -393,7 +394,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
     periods,
     DateTime? nextPeriodDate,
   ) {
-    // distinguish 3 casesL
+    // distinguish 3 cases:
     // - selected date is inside logged period
     // - selected date is inside upcoming period
     // - default builder for all other dates

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -118,6 +118,8 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                             ).colorScheme.secondary,
                       borderRadius: BorderRadius.circular(99),
                     ),
+                        ],
+                      ),
                     const SizedBox(height: 16),
                     Text(
                       status.text,

--- a/lib/pages/log_period_page.dart
+++ b/lib/pages/log_period_page.dart
@@ -410,7 +410,7 @@ class _LogPeriodPageState extends State<LogPeriodPage> {
                       decoration: BoxDecoration(
                         shape: BoxShape.circle,
                         border: Border.all(
-                          color: Theme.of(context).colorScheme.primary,
+                          color: Theme.of(context).colorScheme.secondary,
                           width: 2,
                         ),
                       ),

--- a/lib/pages/onboarding_screen.dart
+++ b/lib/pages/onboarding_screen.dart
@@ -160,11 +160,11 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Text(
-                            '• Period length: number of days your period usually lasts - number of "bleeding" days. [5]',
+                            '• Period length: number of days your period usually lasts - number of "bleeding" days (eg: 5 days)',
                           ),
                           SizedBox(height: 12),
                           Text(
-                            '• Cycle length: number of days from the first day of one period to the first day of the next. [28]',
+                            '• Cycle length: number of days from the first day of one period to the first day of the next (eg: 28 days)',
                           ),
                         ],
                       ),
@@ -274,7 +274,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
               FocusScope.of(context).unfocus();
               return CalendarDatePicker(
                 initialDate: _lastPeriodDate ?? DateTime.now(),
-                firstDate: DateTime(2000),
+                firstDate: kFirstCalendarDay,
                 lastDate: DateTime.now(),
                 onDateChanged: (picked) {
                   setState(() {

--- a/lib/providers/period_provider.dart
+++ b/lib/providers/period_provider.dart
@@ -121,16 +121,8 @@ class PeriodProvider extends ChangeNotifier {
 
     _periods.sort((a, b) => a.startDate.compareTo(b.startDate));
     final lastPeriod = _periods.last;
-    final lastStart = DateTime(
-      lastPeriod.startDate.year,
-      lastPeriod.startDate.month,
-      lastPeriod.startDate.day,
-    );
-    final lastEnd = DateTime(
-      lastPeriod.endDate!.year,
-      lastPeriod.endDate!.month,
-      lastPeriod.endDate!.day,
-    );
+    final lastStart = DateTimeHelper.stripTime(lastPeriod.startDate);
+    final lastEnd = DateTimeHelper.stripTime(lastPeriod.endDate!);
     final now = DateTime.now();
     final DateTime today = DateTime.utc(now.year, now.month, now.day);
 

--- a/lib/providers/period_provider.dart
+++ b/lib/providers/period_provider.dart
@@ -113,7 +113,9 @@ class PeriodProvider extends ChangeNotifier {
     );
 
     if (_periods.isEmpty || nextPeriodDate == null) {
-      status.text = 'Not enough data to predict the next period';
+      // in this case status bar on home page is hidden
+      status.text =
+          'Start by tapping the + button bellow to log your most recent period.';
       return status;
     }
 

--- a/lib/providers/period_provider.dart
+++ b/lib/providers/period_provider.dart
@@ -152,8 +152,12 @@ class PeriodProvider extends ChangeNotifier {
   }
 
   // Returns average cycle length in days
-  double? getAverageCycleLength() {
-    if (_periods.length < 2) return null;
+  double? getAverageCycleLength({int? userCycleLength}) {
+    if (_periods.length < 2) {
+      // not enough data to calculate average cycle length - use the user provided cycle length if available
+      // returns null if userCycleLength is null
+      return userCycleLength?.toDouble();
+    }
     final sorted = List<Period>.from(_periods)
       ..sort((a, b) => a.startDate.compareTo(b.startDate));
     List<int> cycles = [];

--- a/lib/providers/period_provider.dart
+++ b/lib/providers/period_provider.dart
@@ -153,6 +153,7 @@ class PeriodProvider extends ChangeNotifier {
 
   // Returns average cycle length in days
   double? getAverageCycleLength({int? userCycleLength}) {
+    if (_periods.isEmpty) return null;
     if (_periods.length < 2) {
       // not enough data to calculate average cycle length - use the user provided cycle length if available
       // returns null if userCycleLength is null

--- a/lib/services/period_service.dart
+++ b/lib/services/period_service.dart
@@ -41,13 +41,6 @@ class PeriodService {
     return false;
   }
 
-  static bool isInPeriod(DateTime day, List<Period> periods) {
-    final checkDay = DateTime.utc(day.year, day.month, day.day);
-    Period? period = getPeriodInDate(checkDay, periods);
-    if (period != null) return true;
-    return false;
-  }
-
   static bool isStartDay(DateTime day, List<Period> periods) {
     return periods.any(
       (p) =>

--- a/lib/utils/date_time_helper.dart
+++ b/lib/utils/date_time_helper.dart
@@ -27,4 +27,28 @@ class DateTimeHelper {
     final nextDay = date.add(const Duration(days: 1));
     return nextDay.day == 1;
   }
+
+  static bool isSameDay(DateTime date1, DateTime date2) {
+    return date1.year == date2.year &&
+        date1.month == date2.month &&
+        date1.day == date2.day;
+  }
+
+  static bool dayBetweenDates(
+    DateTime checkDate,
+    DateTime startDate,
+    DateTime endDate,
+  ) {
+    checkDate = stripTime(checkDate);
+    startDate = stripTime(startDate);
+    endDate = stripTime(endDate);
+
+    return (checkDate.isAtSameMomentAs(startDate) ||
+            checkDate.isAfter(startDate)) &&
+        (checkDate.isAtSameMomentAs(endDate) || checkDate.isBefore(endDate));
+  }
+
+  static DateTime stripTime(DateTime date) {
+    return DateTime(date.year, date.month, date.day);
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none'
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.1+5
+version: 1.0.2+6
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
- status bar only displayed if at least 1 period is logged
- status bar always displays status (not just for >= 2 periods logged)  
- mark upcoming period on calendar
- gradient for periods that span over multiple months 
- profile page: always display period and cycle length (disable if dynamic mode)