### PR TITLE
fix: #22 - Sorting periods by date from insight page

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -464,11 +464,10 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
               period != null &&
               period.startDate.month != period.endDate!.month;
 
-    final upComingSpanMultipleMonths = isFirstDayOfMonth || isLastDayOfMonth;
-
     bool insideUpcomingPeriod = false;
     bool isNextPeriodStartDay = false;
     bool isNextPeriodEndDay = false;
+    bool upComingSpanMultipleMonths = false;
     int periodDuration = kDefaultPeriodLength - 1;
     if (user != null) {
       periodDuration = user.periodLength - 1;
@@ -486,6 +485,12 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
         isNextPeriodStartDay = DateTimeHelper.isSameDay(periodStart, day);
         isNextPeriodEndDay = DateTimeHelper.isSameDay(periodEnd, day);
         insideUpcomingPeriod = true;
+
+        // Check if this upcoming period actually spans multiple months
+        upComingSpanMultipleMonths =
+            (isFirstDayOfMonth || isLastDayOfMonth) &&
+            periodStart.month != periodEnd.month;
+
         break; // Only consider the first matching period
       }
     }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -486,7 +486,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
         isNextPeriodEndDay = DateTimeHelper.isSameDay(periodEnd, day);
         insideUpcomingPeriod = true;
 
-        // Check if this upcoming period actually spans multiple months
+        // Check if this upcoming period spans multiple months
         upComingSpanMultipleMonths =
             (isFirstDayOfMonth || isLastDayOfMonth) &&
             periodStart.month != periodEnd.month;

--- a/lib/pages/insights_page.dart
+++ b/lib/pages/insights_page.dart
@@ -13,15 +13,107 @@ class InsightsPage extends StatefulWidget {
   State<InsightsPage> createState() => _InsightsPageState();
 }
 
+enum SortOption {
+  dateNewest,
+  dateOldest,
+  periodLengthShortest,
+  periodLengthLongest,
+  cycleLengthShortest,
+  cycleLengthLongest,
+}
+
 class _InsightsPageState extends State<InsightsPage> {
+  SortOption _currentSortOption = SortOption.dateNewest;
+
+  String _getSortOptionText(SortOption option) {
+    switch (option) {
+      case SortOption.dateNewest:
+        return 'Date (Newest First)';
+      case SortOption.dateOldest:
+        return 'Date (Oldest First)';
+      case SortOption.periodLengthShortest:
+        return 'Period Length (Shortest)';
+      case SortOption.periodLengthLongest:
+        return 'Period Length (Longest)';
+      case SortOption.cycleLengthShortest:
+        return 'Cycle Length (Shortest)';
+      case SortOption.cycleLengthLongest:
+        return 'Cycle Length (Longest)';
+    }
+  }
+
+  List<Period> _sortPeriods(List<Period> periods, SortOption sortOption) {
+    List<Period> sortedPeriods = List.from(periods);
+
+    switch (sortOption) {
+      case SortOption.dateNewest:
+        sortedPeriods.sort((a, b) => b.startDate.compareTo(a.startDate));
+        break;
+      case SortOption.dateOldest:
+        sortedPeriods.sort((a, b) => a.startDate.compareTo(b.startDate));
+        break;
+      case SortOption.periodLengthShortest:
+        sortedPeriods.sort((a, b) {
+          int lengthA = a.endDate != null
+              ? a.endDate!.difference(a.startDate).inDays + 1
+              : 0;
+          int lengthB = b.endDate != null
+              ? b.endDate!.difference(b.startDate).inDays + 1
+              : 0;
+          return lengthA.compareTo(lengthB);
+        });
+        break;
+      case SortOption.periodLengthLongest:
+        sortedPeriods.sort((a, b) {
+          int lengthA = a.endDate != null
+              ? a.endDate!.difference(a.startDate).inDays + 1
+              : 0;
+          int lengthB = b.endDate != null
+              ? b.endDate!.difference(b.startDate).inDays + 1
+              : 0;
+          return lengthB.compareTo(lengthA);
+        });
+        break;
+      case SortOption.cycleLengthShortest:
+      case SortOption.cycleLengthLongest:
+        // Sort by cycle length (gap between periods)
+        // First, sort by date to ensure proper order for cycle calculations
+        sortedPeriods.sort((a, b) => a.startDate.compareTo(b.startDate));
+
+        Map<Period, int> cycleLengths = {};
+
+        for (int i = 1; i < sortedPeriods.length; i++) {
+          int cycleLength = sortedPeriods[i].startDate
+              .difference(sortedPeriods[i - 1].startDate)
+              .inDays;
+          cycleLengths[sortedPeriods[i]] = cycleLength;
+        }
+
+        // Sort based on cycle lengths
+        sortedPeriods.sort((a, b) {
+          int cycleA = cycleLengths[a] ?? 0;
+          int cycleB = cycleLengths[b] ?? 0;
+
+          // Periods without cycle length (first period) go to the end
+          if (cycleA == 0 && cycleB != 0) return 1;
+          if (cycleB == 0 && cycleA != 0) return -1;
+          if (cycleA == 0 && cycleB == 0) return 0;
+
+          return sortOption == SortOption.cycleLengthShortest
+              ? cycleA.compareTo(cycleB)
+              : cycleB.compareTo(cycleA);
+        });
+        break;
+    }
+
+    return sortedPeriods;
+  }
+
   @override
   Widget build(BuildContext context) {
     final periodProvider = Provider.of<PeriodProvider>(context);
     List<Period> periods = context.watch<PeriodProvider>().periods;
-    // TODO: support sorting from UI
-    periods.sort(
-      (a, b) => b.startDate.compareTo(a.startDate),
-    ); // default sorting by date descending
+    List<Period> sortedPeriods = _sortPeriods(periods, _currentSortOption);
 
     return SafeArea(
       child: periods.isEmpty
@@ -81,13 +173,143 @@ class _InsightsPageState extends State<InsightsPage> {
                       ],
                     ),
                   ),
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: SectionTitle('Period History'),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          SectionTitle(
+                            'Period History',
+                            padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+                          ),
+                          if (periods.length > 1)
+                            Padding(
+                              padding: const EdgeInsets.only(
+                                left: 16.0,
+                                bottom: 8,
+                              ),
+                              child: Text(
+                                'Sorted by: ${_getSortOptionText(_currentSortOption)}',
+                                style: Theme.of(context).textTheme.bodySmall
+                                    ?.copyWith(
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.onSurfaceVariant,
+                                    ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                    if (periods.length > 1)
+                      PopupMenuButton<SortOption>(
+                        icon: Icon(
+                          Icons.sort_rounded,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                        tooltip: 'Sort periods',
+                        onSelected: (SortOption value) {
+                          setState(() {
+                            _currentSortOption = value;
+                          });
+                        },
+                        itemBuilder: (BuildContext context) =>
+                            SortOption.values.map((option) {
+                              IconData optionIcon;
+                              switch (option) {
+                                case SortOption.dateNewest:
+                                  optionIcon = Icons.schedule_rounded;
+                                  break;
+                                case SortOption.dateOldest:
+                                  optionIcon = Icons.history_rounded;
+                                  break;
+                                case SortOption.periodLengthShortest:
+                                case SortOption.periodLengthLongest:
+                                  optionIcon = Icons.straighten_rounded;
+                                  break;
+                                case SortOption.cycleLengthShortest:
+                                case SortOption.cycleLengthLongest:
+                                  optionIcon = Icons.refresh_rounded;
+                                  break;
+                              }
+
+                              return PopupMenuItem<SortOption>(
+                                value: option,
+                                child: Row(
+                                  children: [
+                                    Icon(
+                                      optionIcon,
+                                      size: 18,
+                                      color: _currentSortOption == option
+                                          ? Theme.of(
+                                              context,
+                                            ).colorScheme.primary
+                                          : Theme.of(
+                                              context,
+                                            ).colorScheme.onSurfaceVariant,
+                                    ),
+                                    const SizedBox(width: 12),
+                                    Expanded(
+                                      child: Text(
+                                        _getSortOptionText(option),
+                                        style: TextStyle(
+                                          fontWeight:
+                                              _currentSortOption == option
+                                              ? FontWeight.w600
+                                              : FontWeight.normal,
+                                          color: _currentSortOption == option
+                                              ? Theme.of(
+                                                  context,
+                                                ).colorScheme.primary
+                                              : null,
+                                        ),
+                                      ),
+                                    ),
+                                    if (_currentSortOption == option)
+                                      Icon(
+                                        Icons.check_rounded,
+                                        size: 16,
+                                        color: Theme.of(
+                                          context,
+                                        ).colorScheme.primary,
+                                      ),
+                                  ],
+                                ),
+                              );
+                            }).toList(),
+                      ),
+                  ],
                 ),
                 Expanded(
                   child: ListView(
-                    children: periods.map((period) {
+                    children: sortedPeriods.map((period) {
+                      int? periodLength = period.endDate != null
+                          ? period.endDate!
+                                    .difference(period.startDate)
+                                    .inDays +
+                                1
+                          : null;
+
+                      // Calculate cycle length for this period (if not the first one chronologically)
+                      int? cycleLength;
+
+                      // Always use date-sorted periods to find the chronologically previous period
+                      List<Period> dateSortedPeriods = List.from(periods);
+                      dateSortedPeriods.sort(
+                        (a, b) => a.startDate.compareTo(b.startDate),
+                      );
+
+                      int dateIndex = dateSortedPeriods.indexOf(period);
+                      if (dateIndex > 0) {
+                        cycleLength = period.startDate
+                            .difference(
+                              dateSortedPeriods[dateIndex - 1].startDate,
+                            )
+                            .inDays;
+                      }
+
                       return ListTile(
                         leading: Icon(
                           Icons.calendar_month_rounded,
@@ -96,10 +318,50 @@ class _InsightsPageState extends State<InsightsPage> {
                         title: Text(
                           'Start: ${DateTimeHelper.displayDate(period.startDate)}',
                         ),
-                        subtitle: Text(
-                          period.endDate != null
-                              ? 'End: ${DateTimeHelper.displayDate(period.endDate!)}'
-                              : 'Ongoing',
+                        subtitle: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              period.endDate != null
+                                  ? 'End: ${DateTimeHelper.displayDate(period.endDate!)}'
+                                  : 'Ongoing',
+                            ),
+                            if (periodLength != null &&
+                                (_currentSortOption ==
+                                        SortOption.periodLengthShortest ||
+                                    _currentSortOption ==
+                                        SortOption.periodLengthLongest))
+                              Text(
+                                'Length: $periodLength day${periodLength == 1 ? '' : 's'}',
+                                style: Theme.of(context).textTheme.bodySmall
+                                    ?.copyWith(
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.tertiary,
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                              ),
+                            if ((_currentSortOption ==
+                                    SortOption.cycleLengthShortest ||
+                                _currentSortOption ==
+                                    SortOption.cycleLengthLongest))
+                              Text(
+                                cycleLength != null
+                                    ? 'Cycle: $cycleLength day${cycleLength == 1 ? '' : 's'}'
+                                    : 'First Period',
+                                style: Theme.of(context).textTheme.bodySmall
+                                    ?.copyWith(
+                                      color: cycleLength != null
+                                          ? Theme.of(
+                                              context,
+                                            ).colorScheme.tertiary
+                                          : Theme.of(
+                                              context,
+                                            ).colorScheme.tertiary,
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                              ),
+                          ],
                         ),
                         trailing: Icon(Icons.chevron_right_rounded),
                         onTap: () {
@@ -119,26 +381,33 @@ class _InsightsPageState extends State<InsightsPage> {
 
   Widget _statCard({required String title, required String value}) {
     return Card(
+      clipBehavior: Clip.antiAlias,
       color: Theme.of(context).colorScheme.secondary,
       margin: const EdgeInsets.all(8),
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Center(
-              child: Text(title, style: Theme.of(context).textTheme.bodyMedium),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              value,
-              style: Theme.of(
-                context,
-              ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
-            ),
-          ],
+      child: InkWell(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Center(
+                child: Text(
+                  title,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                value,
+                style: Theme.of(
+                  context,
+                ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+              ),
+            ],
+          ),
         ),
+        onTap: () {},
       ),
     );
   }

--- a/lib/providers/period_provider.dart
+++ b/lib/providers/period_provider.dart
@@ -101,37 +101,51 @@ class PeriodProvider extends ChangeNotifier {
   int getCurrentCycleDay([DateTime? date]) {
     if (_periods.isEmpty) return 0;
 
-    // Normalize to local
+    // Normalize to UTC date only (strip time)
     date ??= DateTime.now();
-    date = date.toLocal();
+    final targetDate = DateTime.utc(date.year, date.month, date.day);
 
     _periods.sort((a, b) => a.startDate.compareTo(b.startDate));
 
-    if (date.isBefore(_periods.first.startDate.toLocal())) {
+    // Normalize period dates to UTC date only for consistent comparison
+    final normalizedPeriods = _periods.map((p) {
+      final startDate = DateTime.utc(
+        p.startDate.year,
+        p.startDate.month,
+        p.startDate.day,
+      );
+      final endDate = p.endDate != null
+          ? DateTime.utc(p.endDate!.year, p.endDate!.month, p.endDate!.day)
+          : null;
+      return {'period': p, 'start': startDate, 'end': endDate};
+    }).toList();
+
+    // Check if target date is before the first period
+    if (targetDate.isBefore(normalizedPeriods.first['start'] as DateTime)) {
       return 0;
     }
 
     // Find the most recent period that started before or on this date
-    Period? lastPeriod;
-    for (var p in _periods) {
-      if (!date.isBefore(p.startDate.toLocal())) {
-        lastPeriod = p;
+    Map<String, dynamic>? lastPeriodData;
+    for (var periodData in normalizedPeriods) {
+      final startDate = periodData['start'] as DateTime;
+      if (targetDate.isAtSameMomentAs(startDate) ||
+          targetDate.isAfter(startDate)) {
+        lastPeriodData = periodData;
       } else {
         break;
       }
     }
 
-    if (lastPeriod == null) return 0;
+    if (lastPeriodData == null) return 0;
 
-    // If within that period
-    final start = lastPeriod.startDate.toLocal();
-    final end = lastPeriod.endDate?.toLocal();
-    if (end == null || !date.isAfter(end)) {
-      return date.difference(start).inDays + 1;
-    }
+    final start = lastPeriodData['start'] as DateTime;
 
-    // If after that period ended count from start
-    return date.difference(start).inDays + 1;
+    // Calculate days from the start of the most recent period
+    int daysSinceStart = targetDate.difference(start).inDays + 1;
+
+    // Ensure we return at least day 1 if we're on or after the start date
+    return daysSinceStart > 0 ? daysSinceStart : 1;
   }
 
   // Returns a status message (e.g., late, on track)
@@ -224,7 +238,7 @@ class PeriodProvider extends ChangeNotifier {
     Period? period = PeriodService.getPeriodInDate(checkDate, periods);
     if (period == null) {
       return Text(
-        'Cycle Day: ${getCurrentCycleDay(checkDate)}',
+        'Cycle Day: $cycleDay',
         style: Theme.of(context).textTheme.bodyMedium,
       );
     }
@@ -240,7 +254,7 @@ class PeriodProvider extends ChangeNotifier {
       child: Column(
         children: [
           Text(
-            'Cycle Day: ${getCurrentCycleDay(checkDate)}',
+            'Cycle Day: $cycleDay',
             style: Theme.of(context).textTheme.bodyMedium,
           ),
           SizedBox(height: 4),

--- a/lib/providers/period_provider.dart
+++ b/lib/providers/period_provider.dart
@@ -161,7 +161,7 @@ class PeriodProvider extends ChangeNotifier {
     if (_periods.isEmpty || nextPeriodDate == null) {
       // in this case status bar on home page is hidden
       status.text =
-          'Start by tapping the + button bellow to log your most recent period.';
+          'Start by tapping the + button bellow to log your most recent period';
       return status;
     }
 

--- a/lib/widgets/section_title.dart
+++ b/lib/widgets/section_title.dart
@@ -2,14 +2,16 @@ import 'package:flutter/material.dart';
 
 class SectionTitle extends StatelessWidget {
   final String title;
-  const SectionTitle(this.title, {super.key});
+  final EdgeInsetsGeometry? padding;
+
+  const SectionTitle(this.title, {super.key, this.padding});
 
   @override
   Widget build(BuildContext context) {
     return Align(
       alignment: Alignment.centerLeft,
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+        padding: padding ?? const EdgeInsets.fromLTRB(16, 16, 16, 8),
         child: Text(
           title,
           style: Theme.of(context).textTheme.titleMedium,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none'
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.2+8
+version: 1.0.3+9
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
Done:
- sort period on insight page by
- fix getCurrentCycleDay method
- UI improvements - make card on insights insights page clickable
- fix gradient displayed for upcoming period that start on the first day of the month or on the last day of the month (and don't span through multiple months)